### PR TITLE
Add accessible error handling to new artist form

### DIFF
--- a/src/NewArtist/NewArtist.css
+++ b/src/NewArtist/NewArtist.css
@@ -1,3 +1,12 @@
 label {
 	font-weight: lighter;
 }
+
+.formError {
+	display: block;
+	margin-top: 4px;
+	font-size: 0.85em;
+	color: #b94a48;
+	font-family: 'Oswald', sans-serif;
+	font-weight: bold;
+}

--- a/src/NewArtist/NewArtist.js
+++ b/src/NewArtist/NewArtist.js
@@ -3,7 +3,7 @@ import useForm from '../NewArtistHook';
 import './NewArtist.css';
 
 function NewArtist(props) {
-	const { inputs, handleInputChange, handleSubmit } = useForm();
+	const { inputs, handleInputChange, handleSubmit, error } = useForm();
 
 	return (
 		<div>
@@ -13,14 +13,21 @@ function NewArtist(props) {
 			<form onSubmit={handleSubmit}>
 				<div className='editInputs'>
 					<div>
-						<label>Artist:</label>
+						<label htmlFor='artist'>Artist:</label>
 						<input
+							required
 							className='inputField'
 							type='text'
 							name='artist'
 							id='artist'
 							value={inputs.artist}
+							aria-describedby={error ? 'artist-error' : undefined}
 							onChange={handleInputChange}></input>
+						{error && (
+							<span id='artist-error' role='alert' className='formError'>
+								{error}
+							</span>
+						)}
 					</div>
 					<div>
 						<label>Photo URL:</label>

--- a/src/NewArtistHook.js
+++ b/src/NewArtistHook.js
@@ -18,14 +18,27 @@ function useNewArtist() {
 		notes: '',
 		songs: '',
 	});
+	const [error, setError] = useState('');
+
 	const handleSubmit = (event) => {
 		if (event) {
 			event.preventDefault();
+			setError('');
 			const newArtist = inputs;
 			axios
 				.post(requests.postArtistURL, newArtist)
 				.then(() => history.push('/'))
-				.catch((err) => console.log(err));
+				.catch((err) => {
+					if (err.response && err.response.status === 400) {
+						const data = err.response.data;
+						const msg = data.artist
+							? data.artist[0]
+							: 'Something went wrong. Please try again.';
+						setError(msg);
+					} else {
+						setError('Something went wrong. Please try again.');
+					}
+				});
 		}
 	};
 	const handleInputChange = (event) => {
@@ -40,6 +53,7 @@ function useNewArtist() {
 		handleSubmit,
 		handleInputChange,
 		inputs,
+		error,
 	};
 }
 


### PR DESCRIPTION
- Prevent empty form submission with required attribute on artist field
- Display inline error message with role="alert" and aria-describedby so screen readers announce errors without user navigation
- Parse error message directly from backend response for accuracy