### PR TITLE
Add search/sort, artist combobox, inline artist creation, and form improvements

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -5,6 +5,7 @@ import NavBar from './NavBar/NavBar';
 import RecordsList from './RecordsList/RecordsList';
 import NewRecord from './NewRecord/NewRecord';
 import NewArtist from './NewArtist/NewArtist';
+import SearchSort from './SearchSort/SearchSort';
 import axios from './axios';
 import requests from './requests';
 import './App.css';
@@ -13,6 +14,9 @@ function AppContent() {
 	const [data, setData] = useState([]);
 	const [show, setShow] = useState(false);
 	const [currentRecord, setCurrentRecord] = useState({});
+	const [searchQuery, setSearchQuery] = useState('');
+	const [sortBy, setSortBy] = useState('default');
+	const [sortAsc, setSortAsc] = useState(true);
 	const location = useLocation();
 
 	useEffect(() => {
@@ -23,7 +27,6 @@ function AppContent() {
 		getRecords();
 	}, [location]);
 
-	//handleShow and handleClose for RecordModal
 	const handleShow = (record) => {
 		setShow(true);
 		setCurrentRecord(record);
@@ -46,6 +49,24 @@ function AppContent() {
 		handleClose();
 	};
 
+	const filteredAndSorted = data
+		.filter((r) => {
+			if (!searchQuery) return true;
+			const q = searchQuery.toLowerCase();
+			return (
+				(r.title && r.title.toLowerCase().includes(q)) ||
+				(r.artist_string && r.artist_string.toLowerCase().includes(q))
+			);
+		})
+		.sort((a, b) => {
+			if (sortBy === 'default') return sortAsc ? a.id - b.id : b.id - a.id;
+			const aVal = a[sortBy] || '';
+			const bVal = b[sortBy] || '';
+			if (aVal < bVal) return sortAsc ? -1 : 1;
+			if (aVal > bVal) return sortAsc ? 1 : -1;
+			return 0;
+		});
+
 	return (
 		<div className='App'>
 			<nav>
@@ -55,32 +76,36 @@ function AppContent() {
 				<Route
 					path='/'
 					exact
-					render={(props) => {
-						return (
+					render={() => (
+						<>
+							<SearchSort
+								searchQuery={searchQuery}
+								onSearchChange={setSearchQuery}
+								sortBy={sortBy}
+								onSortChange={setSortBy}
+								sortAsc={sortAsc}
+								onSortDirectionToggle={() => setSortAsc((prev) => !prev)}
+							/>
 							<RecordsList
 								currentRecord={currentRecord}
 								show={show}
-								records={data}
+								records={filteredAndSorted}
 								handleShow={handleShow}
 								handleClose={handleClose}
 								handleRecordUpdated={handleRecordUpdated}
 								handleRecordDeleted={handleRecordDeleted}
 							/>
-						);
-					}}
+						</>
+					)}
 				/>
 				<Route
 					path='/newrecord'
-					render={(props) => {
-						return (
-							<NewRecord albums={data} />
-						);
-					}}></Route>
-				<Route path='/newartist' render={(props) => {
-					return (
-						<NewArtist />
-					);
-				}}></Route>
+					render={() => <NewRecord albums={data} />}
+				/>
+				<Route
+					path='/newartist'
+					render={() => <NewArtist />}
+				/>
 			</main>
 		</div>
 	);

--- a/src/ArtistCombobox/ArtistCombobox.css
+++ b/src/ArtistCombobox/ArtistCombobox.css
@@ -1,6 +1,7 @@
 .artist-combobox {
 	position: relative;
-	display: inline-block;
+	display: block;
+	width: 100%;
 }
 
 .artist-combobox .inputField {

--- a/src/NewArtist/NewArtist.css
+++ b/src/NewArtist/NewArtist.css
@@ -1,7 +1,3 @@
-label {
-	font-weight: lighter;
-	margin-right: 0.4rem;
-}
 
 .formError {
 	display: block;

--- a/src/NewRecord/NewRecord.css
+++ b/src/NewRecord/NewRecord.css
@@ -1,7 +1,3 @@
-label {
-	font-weight: lighter;
-	margin-right: 0.4rem;
-}
 
 
 .new-artist-toggle {

--- a/src/SearchSort/SearchSort.css
+++ b/src/SearchSort/SearchSort.css
@@ -1,0 +1,43 @@
+.search-sort {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 0.5rem;
+	align-items: center;
+	padding: 0.75rem 1rem;
+}
+
+.search-input {
+	flex: 1;
+	min-width: 160px;
+}
+
+.sort-controls {
+	display: flex;
+	align-items: center;
+	gap: 0;
+}
+
+.sort-label {
+	font-family: 'Oswald', sans-serif;
+	font-weight: lighter;
+	margin-right: 0.4rem;
+	white-space: nowrap;
+}
+
+
+.sort-direction-btn {
+	font-family: 'Oswald', sans-serif;
+	font-size: 1rem;
+	border: 1px solid #555555;
+	padding: 0 0.6rem;
+	cursor: pointer;
+	background-color: transparent;
+	color: #555555;
+	border-radius: 0;
+	align-self: stretch;
+}
+
+.sort-direction-btn:hover {
+	background-color: #555555;
+	color: #eeeeee;
+}

--- a/src/SearchSort/SearchSort.js
+++ b/src/SearchSort/SearchSort.js
@@ -1,0 +1,44 @@
+import React from 'react';
+import SortDropdown from './SortDropdown';
+import './SearchSort.css';
+
+const SORT_OPTIONS = [
+	{ value: 'default', label: 'Default' },
+	{ value: 'title', label: 'Title' },
+	{ value: 'artist_string', label: 'Artist' },
+	{ value: 'genre', label: 'Genre' },
+	{ value: 'label', label: 'Label' },
+	{ value: 'release_date', label: 'Date released' },
+	{ value: 'acquired_date', label: 'Date acquired' },
+];
+
+function SearchSort({ searchQuery, onSearchChange, sortBy, onSortChange, sortAsc, onSortDirectionToggle }) {
+	return (
+		<div className='search-sort'>
+			<input
+				className='inputField search-input'
+				type='text'
+				placeholder='Search by title or artist...'
+				value={searchQuery}
+				onChange={(e) => onSearchChange(e.target.value)}
+			/>
+			<div className='sort-controls'>
+				<span className='sort-label'>Sort by:</span>
+				<SortDropdown
+					options={SORT_OPTIONS}
+					value={sortBy}
+					onChange={onSortChange}
+				/>
+				<button
+					type='button'
+					className='sort-direction-btn'
+					onClick={onSortDirectionToggle}
+					title={sortAsc ? 'Ascending' : 'Descending'}>
+					{sortAsc ? '↑' : '↓'}
+				</button>
+			</div>
+		</div>
+	);
+}
+
+export default SearchSort;

--- a/src/SearchSort/SortDropdown.css
+++ b/src/SearchSort/SortDropdown.css
@@ -1,0 +1,67 @@
+.sort-dropdown {
+	position: relative;
+}
+
+.sort-dropdown-toggle {
+	font-family: 'Oswald', sans-serif;
+	font-weight: lighter;
+	border: 1px solid #555555;
+	border-right: none;
+	border-radius: 0;
+	padding: 0.25rem 0.5rem;
+	background-color: #ffffff;
+	color: #333333;
+	cursor: pointer;
+	display: flex;
+	align-items: center;
+	gap: 0.5rem;
+	white-space: nowrap;
+	height: 100%;
+}
+
+.sort-dropdown-toggle:hover {
+	background-color: #f5f5f5;
+}
+
+.sort-dropdown-arrow {
+	font-size: 0.6rem;
+	color: #555555;
+}
+
+.sort-dropdown-list {
+	position: absolute;
+	top: 100%;
+	left: 0;
+	min-width: 100%;
+	background-color: #ffffff;
+	border: 1px solid #555555;
+	border-top: none;
+	list-style: none;
+	margin: 0;
+	padding: 0;
+	z-index: 100;
+}
+
+.sort-dropdown-item {
+	font-family: 'Oswald', sans-serif;
+	font-weight: lighter;
+	padding: 0.35rem 0.6rem;
+	cursor: pointer;
+	text-align: left;
+	white-space: nowrap;
+}
+
+.sort-dropdown-item:hover {
+	background-color: #555555;
+	color: #eeeeee;
+}
+
+.sort-dropdown-item.selected {
+	color: #555555;
+	font-weight: normal;
+}
+
+.sort-dropdown-item.selected:hover {
+	background-color: #555555;
+	color: #eeeeee;
+}

--- a/src/SearchSort/SortDropdown.js
+++ b/src/SearchSort/SortDropdown.js
@@ -1,0 +1,50 @@
+import React, { useState, useRef, useEffect } from 'react';
+import './SortDropdown.css';
+
+function SortDropdown({ options, value, onChange }) {
+	const [isOpen, setIsOpen] = useState(false);
+	const containerRef = useRef(null);
+
+	const selected = options.find((o) => o.value === value);
+
+	useEffect(() => {
+		const handleClickOutside = (e) => {
+			if (containerRef.current && !containerRef.current.contains(e.target)) {
+				setIsOpen(false);
+			}
+		};
+		document.addEventListener('mousedown', handleClickOutside);
+		return () => document.removeEventListener('mousedown', handleClickOutside);
+	}, []);
+
+	const handleSelect = (val) => {
+		onChange(val);
+		setIsOpen(false);
+	};
+
+	return (
+		<div className='sort-dropdown' ref={containerRef}>
+			<button
+				type='button'
+				className='sort-dropdown-toggle'
+				onClick={() => setIsOpen((prev) => !prev)}>
+				{selected ? selected.label : 'Select'}
+				<span className='sort-dropdown-arrow'>{isOpen ? '▲' : '▼'}</span>
+			</button>
+			{isOpen && (
+				<ul className='sort-dropdown-list'>
+					{options.map((opt) => (
+						<li
+							key={opt.value}
+							className={`sort-dropdown-item${opt.value === value ? ' selected' : ''}`}
+							onMouseDown={() => handleSelect(opt.value)}>
+							{opt.label}
+						</li>
+					))}
+				</ul>
+			)}
+		</div>
+	);
+}
+
+export default SortDropdown;

--- a/src/index.css
+++ b/src/index.css
@@ -22,10 +22,32 @@ code {
 	background-color: #ffffff;
 	color: #333333;
 	outline: none;
+	width: 100%;
+	box-sizing: border-box;
 }
 
 .inputField:focus {
 	border-color: #333333;
+}
+
+.editInputs {
+	display: flex;
+	flex-direction: column;
+	max-width: 360px;
+	margin: 0 auto;
+	text-align: left;
+}
+
+.editInputs > div {
+	display: flex;
+	flex-direction: column;
+	margin-bottom: 0.4rem;
+}
+
+.editInputs label {
+	display: block;
+	margin-bottom: 0.1rem;
+	margin-right: 0;
 }
 
 .submitButton {


### PR DESCRIPTION
## Summary

- Fix song reorder not persisting on save (race condition between track PATCHes and album PUT)
- Add inline artist creation directly from the New Record form
- Replace artist `<select>` with searchable combobox (ArtistCombobox) with keyboard navigation (Arrow keys, Enter, Escape, Tab)
- Add error handling and duplicate detection to New Record form
- Fix form styling across New Record and New Artist (Oswald font, square corners, consistent gray palette)
- Add search and sort to record list home page (search by title/artist, sort by default/title/artist, reversible direction)
- Improve form layout — stacked labels above inputs, tighter spacing
- Remove unused NewRecordModal stub
- Add `.claude/` to .gitignore

## Test plan

- [ ] Add a new record with an existing artist via the combobox (type to filter, keyboard navigate, click to select)
- [ ] Add a new record using inline artist creation (click "+ New artist", fill name, confirm)
- [ ] Try submitting a duplicate record — confirm warning appears with Cancel / Add anyway options
- [ ] Reorder songs in a record modal, click Save — confirm new order persists after save
- [ ] Search for a record by title and by artist name on home page
- [ ] Sort by title, artist, and default; toggle direction with the arrow button
- [ ] Confirm all form fields have square corners, Oswald font, and consistent styling

🤖 Generated with [Claude Code](https://claude.com/claude-code)