### PR TITLE
Add BottomSheet and UI polish

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,16 +35,14 @@ DATABASE_URL=postgresql://rc_user:records@localhost:5432/record_collection_be
 ```bash
 cd frontend
 npm install
-NODE_OPTIONS=--openssl-legacy-provider npm start
+npm start
 ```
 
 Requires a `.env.local` file in `frontend/` with:
 ```
-REACT_APP_DEV_URL=http://localhost:8000
-REACT_APP_PROD_URL=https://your-deployed-backend-url.com
+VITE_DEV_URL=http://localhost:8000
+VITE_PROD_URL=https://your-deployed-backend-url.com
 ```
-
-> Note: `NODE_OPTIONS=--openssl-legacy-provider` is required due to an incompatibility between the current Node.js version and the webpack version used by react-scripts 3.x. A migration to Vite is planned and will eliminate this.
 
 <br>
 
@@ -98,7 +96,7 @@ REACT_APP_PROD_URL=https://your-deployed-backend-url.com
 
 ## Tech Stack
 
-**Frontend:** React 16, React Router 5, React Bootstrap, Axios — migration to Vite + React 18 planned
+**Frontend:** React 18, React Router 5, Vite, Axios
 
 **Backend:** Django, Django REST Framework, PostgreSQL
 
@@ -115,7 +113,7 @@ REACT_APP_PROD_URL=https://your-deployed-backend-url.com
 
 **Album**
 - `title`
-- `artist` — foreign key to Artist
+- `artist` — foreign key to Artist (PROTECT — cannot delete artist with albums)
 - `release_date` — optional
 - `acquired_date` — optional
 - `genre` — optional
@@ -133,7 +131,7 @@ REACT_APP_PROD_URL=https://your-deployed-backend-url.com
 **Song**
 - `title`
 - `track` — track number
-- `artist` — foreign key to Artist (used for featured artists)
+- `artist` — foreign key to Artist, SET_NULL (used for featured artists)
 - `album` — foreign key to Album
 - `song_url` — optional
 
@@ -146,10 +144,10 @@ REACT_APP_PROD_URL=https://your-deployed-backend-url.com
 | P0 | Edit and delete albums | Complete |
 | P1 | Tracklist display and management | Complete |
 | P1 | Search and sort | Complete |
-| P1 | Edit and delete artists (UI) | Not started |
-| P2 | Vite + React 18 migration | Not started |
+| P1 | Edit and delete artists (UI) | Complete |
+| P2 | Vite + React 18 migration | Complete |
+| P2 | Mobile UX — bottom sheet modal, tap targets | Complete |
 | P2 | Google OAuth / multi-user auth (Clerk) | Not started |
-| P2 | Mobile UX — bottom sheet modal, tap targets | Not started |
 | P3 | Condition fields (media + sleeve) | Not started |
 | P3 | Pressing details (catalog number, country, pressing) | Not started |
 | P3 | Price paid field | Not started |
@@ -166,8 +164,12 @@ REACT_APP_PROD_URL=https://your-deployed-backend-url.com
 
 UX polish shipped outside the main roadmap:
 
+- **Vite + React 18 migration** — replaced Create React App with Vite; updated to React 18 `createRoot`; switched env vars to `VITE_*`; eliminated `NODE_OPTIONS` workaround
+- **Bootstrap removal** — replaced React Bootstrap modal with a custom `BottomSheet` component; removed Bootstrap CDN; reduced bundle ~22KB
+- **BottomSheet component** — slides up from the bottom on mobile, centered modal on desktop; portal-based (renders outside `.App`); body scroll lock; animated open/close
+- **Artists management hub** — full create, edit, delete at `/artists`; protected delete (can't remove artist with albums); album count shown per artist; full-width search with Escape to clear
 - **Tracklist search** — search now matches song titles in addition to album title and artist, using data already in state (no extra API calls)
-- **Escape key handling** — Escape clears the search bar; in the artist combobox it is two-stage (clears typed text first, then closes dropdown); in the edit modal it does nothing if the form is dirty, preventing accidental loss of unsaved changes including track reordering
+- **Escape key handling** — Escape clears the search bar; in the artist combobox it is two-stage (clears typed text first, then closes dropdown); in the record sheet it does nothing if the form is dirty, preventing accidental loss of unsaved changes including track reordering
 - **Artist exists notice** — when the inline new artist form finds a matching existing artist, it selects them and shows a brief confirmation ("X already exists — selected") rather than silently filling the field or showing an error
 
 ---

--- a/index.html
+++ b/index.html
@@ -11,13 +11,7 @@
 		<meta name="theme-color" content="#000000" />
 		<meta name="description" content="Record Collection" />
 		<link rel="apple-touch-icon" href="/logo192.png" />
-		<link
-			rel="stylesheet"
-			href="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.0/css/bootstrap.min.css"
-			integrity="sha384-9aIt2nRpC12Uk9gS9baDl411NQApFmC26EwAOH8WgZl5MYYxFfc+NcPb1dKGj7Sk"
-			crossorigin="anonymous"
-		/>
-		<link rel="manifest" href="/manifest.json" />
+<link rel="manifest" href="/manifest.json" />
 		<title>Record Collection</title>
 	</head>
 	<body>

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,9 +12,7 @@
 				"@dnd-kit/sortable": "^10.0.0",
 				"@dnd-kit/utilities": "^3.2.2",
 				"axios": "^0.20.0",
-				"bootstrap": "^4.5.2",
 				"react": "^18.3.1",
-				"react-bootstrap": "^1.3.0",
 				"react-dom": "^18.3.1",
 				"react-router": "^5.2.0",
 				"react-router-dom": "^5.2.0"
@@ -970,37 +968,6 @@
 				"@jridgewell/sourcemap-codec": "^1.4.14"
 			}
 		},
-		"node_modules/@popperjs/core": {
-			"version": "2.11.8",
-			"resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
-			"integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
-			"license": "MIT",
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/popperjs"
-			}
-		},
-		"node_modules/@restart/context": {
-			"version": "2.1.4",
-			"resolved": "https://registry.npmjs.org/@restart/context/-/context-2.1.4.tgz",
-			"integrity": "sha512-INJYZQJP7g+IoDUh/475NlGiTeMfwTXUEr3tmRneckHIxNolGOW9CTq83S8cxq0CgJwwcMzMJFchxvlwe7Rk8Q==",
-			"license": "MIT",
-			"peerDependencies": {
-				"react": ">=16.3.2"
-			}
-		},
-		"node_modules/@restart/hooks": {
-			"version": "0.4.16",
-			"resolved": "https://registry.npmjs.org/@restart/hooks/-/hooks-0.4.16.tgz",
-			"integrity": "sha512-f7aCv7c+nU/3mF7NWLtVVr0Ra80RqsO89hO72r+Y/nvQr5+q0UFGkocElTH6MJApvReVh6JHUFYn2cw1WdHF3w==",
-			"license": "MIT",
-			"dependencies": {
-				"dequal": "^2.0.3"
-			},
-			"peerDependencies": {
-				"react": ">=16.8.0"
-			}
-		},
 		"node_modules/@rolldown/pluginutils": {
 			"version": "1.0.0-beta.27",
 			"resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
@@ -1535,23 +1502,21 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/@types/invariant": {
-			"version": "2.2.37",
-			"resolved": "https://registry.npmjs.org/@types/invariant/-/invariant-2.2.37.tgz",
-			"integrity": "sha512-IwpIMieE55oGWiXkQPSBY1nw1nFs6bsKXTFskNY8sdS17K24vyEBRQZEwlRS7ZmXCWnJcQtbxWzly+cODWGs2A==",
-			"license": "MIT"
-		},
 		"node_modules/@types/prop-types": {
 			"version": "15.7.15",
 			"resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
 			"integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-			"license": "MIT"
+			"dev": true,
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/@types/react": {
 			"version": "18.3.28",
 			"resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
 			"integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
+			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@types/prop-types": "*",
 				"csstype": "^3.2.2"
@@ -1566,21 +1531,6 @@
 			"peerDependencies": {
 				"@types/react": "^18.0.0"
 			}
-		},
-		"node_modules/@types/react-transition-group": {
-			"version": "4.4.12",
-			"resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.12.tgz",
-			"integrity": "sha512-8TV6R3h2j7a91c+1DXdJi3Syo69zzIZbz7Lg5tORM5LEJG7X/E6a1V3drRyBRZq7/utz7A+c4OgYLiLcYGHG6w==",
-			"license": "MIT",
-			"peerDependencies": {
-				"@types/react": "*"
-			}
-		},
-		"node_modules/@types/warning": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/@types/warning/-/warning-3.0.3.tgz",
-			"integrity": "sha512-D1XC7WK8K+zZEveUPY+cf4+kgauk8N4eHr/XIHXGlGYkHLud6hK9lYfZk1ry1TNh798cZUCgb6MqGEG8DkJt6Q==",
-			"license": "MIT"
 		},
 		"node_modules/@vitejs/plugin-react": {
 			"version": "4.7.0",
@@ -1863,27 +1813,6 @@
 				"node": ">=6.0.0"
 			}
 		},
-		"node_modules/bootstrap": {
-			"version": "4.6.2",
-			"resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.6.2.tgz",
-			"integrity": "sha512-51Bbp/Uxr9aTuy6ca/8FbFloBUJZLHwnhTcnjIeRn2suQWsWzcuJhGjKDB5eppVte/8oCdOL3VuwxvZDUggwGQ==",
-			"deprecated": "This version of Bootstrap is no longer supported. Please upgrade to the latest version.",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/twbs"
-				},
-				{
-					"type": "opencollective",
-					"url": "https://opencollective.com/bootstrap"
-				}
-			],
-			"license": "MIT",
-			"peerDependencies": {
-				"jquery": "1.9.1 - 3",
-				"popper.js": "^1.16.1"
-			}
-		},
 		"node_modules/browserslist": {
 			"version": "4.28.1",
 			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
@@ -2064,12 +1993,6 @@
 				"node": "*"
 			}
 		},
-		"node_modules/classnames": {
-			"version": "2.5.1",
-			"resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
-			"integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
-			"license": "MIT"
-		},
 		"node_modules/color-convert": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -2164,7 +2087,9 @@
 			"version": "3.2.3",
 			"resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
 			"integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-			"license": "MIT"
+			"dev": true,
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/data-urls": {
 			"version": "5.0.0",
@@ -2308,6 +2233,7 @@
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
 			"integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=6"
@@ -2329,16 +2255,6 @@
 			"integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/dom-helpers": {
-			"version": "5.2.1",
-			"resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
-			"integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
-			"license": "MIT",
-			"dependencies": {
-				"@babel/runtime": "^7.8.7",
-				"csstype": "^3.0.2"
-			}
 		},
 		"node_modules/dunder-proto": {
 			"version": "1.0.1",
@@ -2904,15 +2820,6 @@
 				"node": ">= 0.4"
 			}
 		},
-		"node_modules/invariant": {
-			"version": "2.2.4",
-			"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
-			"integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
-			"license": "MIT",
-			"dependencies": {
-				"loose-envify": "^1.0.0"
-			}
-		},
 		"node_modules/is-arguments": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
@@ -3186,13 +3093,6 @@
 			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
 			"dev": true,
 			"license": "ISC"
-		},
-		"node_modules/jquery": {
-			"version": "3.7.1",
-			"resolved": "https://registry.npmjs.org/jquery/-/jquery-3.7.1.tgz",
-			"integrity": "sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg==",
-			"license": "MIT",
-			"peer": true
 		},
 		"node_modules/js-tokens": {
 			"version": "4.0.0",
@@ -3665,18 +3565,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/popper.js": {
-			"version": "1.16.1",
-			"resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
-			"integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==",
-			"deprecated": "You can find the new Popper v2 at @popperjs/core, this package is dedicated to the legacy v1",
-			"license": "MIT",
-			"peer": true,
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/popperjs"
-			}
-		},
 		"node_modules/possible-typed-array-names": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
@@ -3742,25 +3630,6 @@
 				"react-is": "^16.13.1"
 			}
 		},
-		"node_modules/prop-types-extra": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/prop-types-extra/-/prop-types-extra-1.1.1.tgz",
-			"integrity": "sha512-59+AHNnHYCdiC+vMwY52WmvP5dM3QLeoumYuEyceQDi9aEhtwN9zIQ2ZNo25sMyXnbh32h+P1ezDsUpUH3JAew==",
-			"license": "MIT",
-			"dependencies": {
-				"react-is": "^16.3.2",
-				"warning": "^4.0.0"
-			},
-			"peerDependencies": {
-				"react": ">=0.14.0"
-			}
-		},
-		"node_modules/prop-types-extra/node_modules/react-is": {
-			"version": "16.13.1",
-			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-			"integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-			"license": "MIT"
-		},
 		"node_modules/prop-types/node_modules/react-is": {
 			"version": "16.13.1",
 			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -3809,35 +3678,6 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/react-bootstrap": {
-			"version": "1.6.8",
-			"resolved": "https://registry.npmjs.org/react-bootstrap/-/react-bootstrap-1.6.8.tgz",
-			"integrity": "sha512-yD6uN78XlFOkETQp6GRuVe0s5509x3XYx8PfPbirwFTYCj5/RfmSs9YZGCwkUrhZNFzj7tZPdpb+3k50mK1E4g==",
-			"license": "MIT",
-			"dependencies": {
-				"@babel/runtime": "^7.14.0",
-				"@restart/context": "^2.1.4",
-				"@restart/hooks": "^0.4.7",
-				"@types/invariant": "^2.2.33",
-				"@types/prop-types": "^15.7.3",
-				"@types/react": ">=16.14.8",
-				"@types/react-transition-group": "^4.4.1",
-				"@types/warning": "^3.0.0",
-				"classnames": "^2.3.1",
-				"dom-helpers": "^5.2.1",
-				"invariant": "^2.2.4",
-				"prop-types": "^15.7.2",
-				"prop-types-extra": "^1.1.0",
-				"react-overlays": "^5.1.2",
-				"react-transition-group": "^4.4.1",
-				"uncontrollable": "^7.2.1",
-				"warning": "^4.0.3"
-			},
-			"peerDependencies": {
-				"react": ">=16.8.0",
-				"react-dom": ">=16.8.0"
-			}
-		},
 		"node_modules/react-dom": {
 			"version": "18.3.1",
 			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
@@ -3857,32 +3697,6 @@
 			"integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/react-lifecycles-compat": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
-			"integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==",
-			"license": "MIT"
-		},
-		"node_modules/react-overlays": {
-			"version": "5.2.1",
-			"resolved": "https://registry.npmjs.org/react-overlays/-/react-overlays-5.2.1.tgz",
-			"integrity": "sha512-GLLSOLWr21CqtJn8geSwQfoJufdt3mfdsnIiQswouuQ2MMPns+ihZklxvsTDKD3cR2tF8ELbi5xUsvqVhR6WvA==",
-			"license": "MIT",
-			"dependencies": {
-				"@babel/runtime": "^7.13.8",
-				"@popperjs/core": "^2.11.6",
-				"@restart/hooks": "^0.4.7",
-				"@types/warning": "^3.0.0",
-				"dom-helpers": "^5.2.0",
-				"prop-types": "^15.7.2",
-				"uncontrollable": "^7.2.1",
-				"warning": "^4.0.3"
-			},
-			"peerDependencies": {
-				"react": ">=16.3.0",
-				"react-dom": ">=16.3.0"
-			}
 		},
 		"node_modules/react-refresh": {
 			"version": "0.17.0",
@@ -3937,22 +3751,6 @@
 			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
 			"integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
 			"license": "MIT"
-		},
-		"node_modules/react-transition-group": {
-			"version": "4.4.5",
-			"resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
-			"integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
-			"license": "BSD-3-Clause",
-			"dependencies": {
-				"@babel/runtime": "^7.5.5",
-				"dom-helpers": "^5.0.1",
-				"loose-envify": "^1.4.0",
-				"prop-types": "^15.6.2"
-			},
-			"peerDependencies": {
-				"react": ">=16.6.0",
-				"react-dom": ">=16.6.0"
-			}
 		},
 		"node_modules/redent": {
 			"version": "3.0.0",
@@ -4459,21 +4257,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/uncontrollable": {
-			"version": "7.2.1",
-			"resolved": "https://registry.npmjs.org/uncontrollable/-/uncontrollable-7.2.1.tgz",
-			"integrity": "sha512-svtcfoTADIB0nT9nltgjujTi7BzVmwjZClOmskKu/E8FW9BXzg9os8OLr4f8Dlnk0rYWJIWr4wv9eKUXiQvQwQ==",
-			"license": "MIT",
-			"dependencies": {
-				"@babel/runtime": "^7.6.3",
-				"@types/react": ">=16.9.11",
-				"invariant": "^2.2.4",
-				"react-lifecycles-compat": "^3.0.4"
-			},
-			"peerDependencies": {
-				"react": ">=15.0.0"
-			}
-		},
 		"node_modules/universalify": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
@@ -4692,15 +4475,6 @@
 			},
 			"engines": {
 				"node": ">=18"
-			}
-		},
-		"node_modules/warning": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
-			"integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
-			"license": "MIT",
-			"dependencies": {
-				"loose-envify": "^1.0.0"
 			}
 		},
 		"node_modules/webidl-conversions": {

--- a/package.json
+++ b/package.json
@@ -7,9 +7,7 @@
 		"@dnd-kit/sortable": "^10.0.0",
 		"@dnd-kit/utilities": "^3.2.2",
 		"axios": "^0.20.0",
-		"bootstrap": "^4.5.2",
 		"react": "^18.3.1",
-		"react-bootstrap": "^1.3.0",
 		"react-dom": "^18.3.1",
 		"react-router": "^5.2.0",
 		"react-router-dom": "^5.2.0"

--- a/src/Artists/Artists.css
+++ b/src/Artists/Artists.css
@@ -8,29 +8,30 @@
 .artists-page h4 {
 	font-family: 'Oswald', sans-serif;
 	font-weight: 400;
-	margin-bottom: 1.25rem;
+	margin: 0;
 }
 
-/* Toolbar: add button + search */
+/* Header row: title + add button */
 
-.artists-toolbar {
+.artists-header {
 	display: flex;
-	align-items: flex-start;
+	align-items: center;
 	justify-content: space-between;
-	gap: 1rem;
 	margin-bottom: 1.25rem;
-	flex-wrap: wrap;
 }
+
+/* Search bar */
 
 .artist-search-wrapper {
 	position: relative;
 	display: flex;
 	align-items: center;
+	margin-bottom: 1.25rem;
 }
 
 .artist-search {
 	padding-right: 1.75rem;
-	width: 180px;
+	width: 100%;
 }
 
 .artist-search-clear {
@@ -114,7 +115,7 @@
 	display: flex;
 	flex-direction: column;
 	gap: 0.4rem;
-	max-width: 280px;
+	margin-bottom: 1.25rem;
 }
 
 .artist-form-actions {

--- a/src/Artists/Artists.jsx
+++ b/src/Artists/Artists.jsx
@@ -141,59 +141,9 @@ function Artists() {
 
 	return (
 		<div className='artists-page'>
-			<h4>Artists</h4>
-
-			<div className='artists-toolbar'>
-				{showAdd ? (
-					<div className='artist-add-form'>
-						<input
-							ref={addInputRef}
-							className='inputField'
-							type='text'
-							placeholder='Artist name'
-							value={newName}
-							onChange={(e) => setNewName(e.target.value)}
-							onKeyDown={(e) => {
-								if (e.key === 'Enter') { e.preventDefault(); handleAdd(); }
-								if (e.key === 'Escape') { setShowAdd(false); setNewName(''); setNewPhotoUrl(''); setNewNotes(''); setAddError(''); }
-							}}
-						/>
-						<input
-							className='inputField'
-							type='text'
-							placeholder='Photo URL'
-							value={newPhotoUrl}
-							onChange={(e) => setNewPhotoUrl(e.target.value)}
-							onKeyDown={(e) => {
-								if (e.key === 'Enter') { e.preventDefault(); handleAdd(); }
-								if (e.key === 'Escape') { setShowAdd(false); setNewName(''); setNewPhotoUrl(''); setNewNotes(''); setAddError(''); }
-							}}
-						/>
-						<input
-							className='inputField'
-							type='text'
-							placeholder='Notes'
-							value={newNotes}
-							onChange={(e) => setNewNotes(e.target.value)}
-							onKeyDown={(e) => {
-								if (e.key === 'Enter') { e.preventDefault(); handleAdd(); }
-								if (e.key === 'Escape') { setShowAdd(false); setNewName(''); setNewPhotoUrl(''); setNewNotes(''); setAddError(''); }
-							}}
-						/>
-						{addError && <span role='alert' className='formError'>{addError}</span>}
-						<div className='artist-form-actions'>
-							<button
-								type='button'
-								className='artist-btn'
-								onClick={() => { setShowAdd(false); setNewName(''); setNewPhotoUrl(''); setNewNotes(''); setAddError(''); }}>
-								Cancel
-							</button>
-							<button type='button' className='artist-btn' onClick={handleAdd}>
-								Add
-							</button>
-						</div>
-					</div>
-				) : (
+			<div className='artists-header'>
+				<h4>Artists</h4>
+				{!showAdd && (
 					<button
 						type='button'
 						className='artist-btn'
@@ -201,7 +151,58 @@ function Artists() {
 						+ Add Artist
 					</button>
 				)}
+			</div>
 
+			{showAdd && (
+				<div className='artist-add-form'>
+					<input
+						ref={addInputRef}
+						className='inputField'
+						type='text'
+						placeholder='Artist name'
+						value={newName}
+						onChange={(e) => setNewName(e.target.value)}
+						onKeyDown={(e) => {
+							if (e.key === 'Enter') { e.preventDefault(); handleAdd(); }
+							if (e.key === 'Escape') { setShowAdd(false); setNewName(''); setNewPhotoUrl(''); setNewNotes(''); setAddError(''); }
+						}}
+					/>
+					<input
+						className='inputField'
+						type='text'
+						placeholder='Photo URL'
+						value={newPhotoUrl}
+						onChange={(e) => setNewPhotoUrl(e.target.value)}
+						onKeyDown={(e) => {
+							if (e.key === 'Enter') { e.preventDefault(); handleAdd(); }
+							if (e.key === 'Escape') { setShowAdd(false); setNewName(''); setNewPhotoUrl(''); setNewNotes(''); setAddError(''); }
+						}}
+					/>
+					<textarea
+						className='inputField notes-input'
+						placeholder='Notes'
+						value={newNotes}
+						onChange={(e) => setNewNotes(e.target.value)}
+						onKeyDown={(e) => {
+							if (e.key === 'Escape') { setShowAdd(false); setNewName(''); setNewPhotoUrl(''); setNewNotes(''); setAddError(''); }
+						}}
+					/>
+					{addError && <span role='alert' className='formError'>{addError}</span>}
+					<div className='artist-form-actions'>
+						<button
+							type='button'
+							className='artist-btn'
+							onClick={() => { setShowAdd(false); setNewName(''); setNewPhotoUrl(''); setNewNotes(''); setAddError(''); }}>
+							Cancel
+						</button>
+						<button type='button' className='artist-btn' onClick={handleAdd}>
+							Add
+						</button>
+					</div>
+				</div>
+			)}
+
+			{!showAdd && (
 				<div className='artist-search-wrapper'>
 					<input
 						className='inputField artist-search'
@@ -223,7 +224,7 @@ function Artists() {
 						</button>
 					)}
 				</div>
-			</div>
+			)}
 
 			{loadError && (
 				<p className='formError' style={{ marginTop: '1rem' }}>
@@ -264,9 +265,8 @@ function Artists() {
 												if (e.key === 'Escape') handleEditCancel();
 											}}
 										/>
-										<input
-											className='inputField'
-											type='text'
+										<textarea
+											className='inputField notes-input'
 											placeholder='Notes'
 											value={editNotes}
 											onChange={(e) => setEditNotes(e.target.value)}

--- a/src/BottomSheet/BottomSheet.css
+++ b/src/BottomSheet/BottomSheet.css
@@ -1,0 +1,109 @@
+/* Backdrop — always fixed, full screen */
+.bottom-sheet-backdrop {
+	position: fixed;
+	inset: 0;
+	background: rgba(0, 0, 0, 0.5);
+	z-index: 1000;
+	display: flex;
+	align-items: flex-end; /* mobile: panel anchors to bottom */
+	/* Visibility trick: hidden immediately on hide, visible immediately on show */
+	visibility: hidden;
+	opacity: 0;
+	transition: opacity 250ms ease, visibility 0s 250ms;
+}
+
+.bottom-sheet-backdrop.show {
+	visibility: visible;
+	opacity: 1;
+	transition: opacity 250ms ease, visibility 0s 0s;
+}
+
+/* Panel */
+.bottom-sheet-panel {
+	width: 100%;
+	max-height: 92vh;
+	background: #eeeeee;
+	display: flex;
+	flex-direction: column;
+	overflow: hidden;
+	transform: translateY(100%);
+	transition: transform 300ms ease;
+}
+
+.bottom-sheet-backdrop.show .bottom-sheet-panel {
+	transform: translateY(0);
+}
+
+/* Drag handle (mobile only) */
+.bottom-sheet-handle {
+	display: flex;
+	justify-content: center;
+	padding: 0.6rem 0 0.2rem;
+	flex-shrink: 0;
+}
+
+.bottom-sheet-handle-bar {
+	width: 2.5rem;
+	height: 4px;
+	background: #cccccc;
+	border-radius: 2px;
+}
+
+/* Header */
+.bottom-sheet-header {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	padding: 0.5rem 1rem;
+	border-bottom: 1px solid #dddddd;
+	flex-shrink: 0;
+}
+
+.bottom-sheet-title {
+	font-family: 'Oswald', sans-serif;
+	font-weight: 400;
+	font-size: 1.25rem;
+	margin: 0;
+	color: #333333;
+}
+
+.bottom-sheet-close {
+	background: none;
+	border: none;
+	font-size: 1rem;
+	cursor: pointer;
+	color: #555555;
+	padding: 0.25rem 0.4rem;
+	line-height: 1;
+	font-family: 'Oswald', sans-serif;
+}
+
+.bottom-sheet-close:hover {
+	color: #333333;
+}
+
+/* Scrollable content area */
+.bottom-sheet-content {
+	overflow-y: auto;
+	flex: 1;
+}
+
+/* Desktop — centered modal style */
+@media (min-width: 650px) {
+	.bottom-sheet-backdrop {
+		align-items: center;
+		justify-content: center;
+	}
+
+	.bottom-sheet-panel {
+		width: 90%;
+		max-width: 520px;
+		max-height: 90vh;
+		transform: none;
+		transition: none;
+	}
+
+	.bottom-sheet-handle {
+		display: none;
+	}
+}

--- a/src/BottomSheet/BottomSheet.jsx
+++ b/src/BottomSheet/BottomSheet.jsx
@@ -1,0 +1,51 @@
+import React, { useEffect } from 'react';
+import { createPortal } from 'react-dom';
+import './BottomSheet.css';
+
+function BottomSheet({ show, onClose, title, children }) {
+	// Escape key — delegates to onClose which decides whether to actually close
+	useEffect(() => {
+		if (!show) return;
+		const handleKey = (e) => {
+			if (e.key === 'Escape') onClose();
+		};
+		document.addEventListener('keydown', handleKey);
+		return () => document.removeEventListener('keydown', handleKey);
+	}, [show, onClose]);
+
+	// Lock body scroll when open
+	useEffect(() => {
+		document.body.style.overflow = show ? 'hidden' : '';
+		return () => { document.body.style.overflow = ''; };
+	}, [show]);
+
+	return createPortal(
+		<div
+			className={`bottom-sheet-backdrop${show ? ' show' : ''}`}
+			onClick={onClose}>
+			<div
+				className='bottom-sheet-panel'
+				onClick={(e) => e.stopPropagation()}>
+				<div className='bottom-sheet-handle'>
+					<div className='bottom-sheet-handle-bar' />
+				</div>
+				<div className='bottom-sheet-header'>
+					<h5 className='bottom-sheet-title'>{title}</h5>
+					<button
+						type='button'
+						className='bottom-sheet-close'
+						onClick={onClose}
+						aria-label='Close'>
+						✕
+					</button>
+				</div>
+				<div className='bottom-sheet-content'>
+					{children}
+				</div>
+			</div>
+		</div>,
+		document.body
+	);
+}
+
+export default BottomSheet;

--- a/src/NewRecord/NewRecord.css
+++ b/src/NewRecord/NewRecord.css
@@ -1,4 +1,15 @@
 
+.new-record-page {
+	padding: 1.5rem 2rem;
+	max-width: 600px;
+	margin: 0 auto;
+}
+
+.new-record-page h4 {
+	font-family: 'Oswald', sans-serif;
+	font-weight: 400;
+	margin-bottom: 1.25rem;
+}
 
 .new-artist-toggle {
 	font-family: 'Oswald', sans-serif;
@@ -65,4 +76,11 @@
 	display: flex;
 	justify-content: center;
 	gap: 0.5rem;
+}
+
+.new-record-actions {
+	display: flex;
+	justify-content: center;
+	gap: 0.5rem;
+	margin-top: 0.5rem;
 }

--- a/src/NewRecord/NewRecord.jsx
+++ b/src/NewRecord/NewRecord.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { useHistory } from 'react-router-dom';
 import useForm from '../CustomHooks';
 import ArtistCombobox from '../ArtistCombobox/ArtistCombobox';
 import axios from '../axios';
@@ -7,6 +8,7 @@ import './NewRecord.css';
 
 function NewRecord(props) {
 	const { albums = [] } = props;
+	const history = useHistory();
 	const { inputs, handleInputChange, handleSubmit, setInputs, error } = useForm();
 	const [artists, setArtists] = useState([]);
 	const [showNewArtist, setShowNewArtist] = useState(false);
@@ -71,10 +73,8 @@ function NewRecord(props) {
 	};
 
 	return (
-		<div>
-			<br></br>
+		<div className='new-record-page'>
 			<h4>New Record</h4>
-			<br></br>
 			<form onSubmit={handleFormSubmit} autoComplete='off'>
 				<div className='editInputs'>
 					<div>
@@ -198,14 +198,13 @@ function NewRecord(props) {
 					</div>
 					<div>
 						<label>Notes:</label>
-						<input
-							className='inputField'
-							type='text'
+						<textarea
+							className='inputField notes-input'
 							name='body'
 							id='notes'
 							value={inputs.notes}
 							onChange={handleInputChange}
-						></input>
+						/>
 					</div>
 				</div>
 				{error && (
@@ -233,7 +232,12 @@ function NewRecord(props) {
 						</div>
 					</div>
 				) : (
-					<input type='submit' className='submitButton' />
+					<div className='new-record-actions'>
+						<button type='button' className='submitButton' onClick={() => history.push('/')}>
+							Cancel
+						</button>
+						<input type='submit' className='submitButton' />
+					</div>
 				)}
 			</form>
 		</div>

--- a/src/RecordModal/RecordModal.css
+++ b/src/RecordModal/RecordModal.css
@@ -1,8 +1,21 @@
+.sheet-body .editInputs {
+	max-width: 100%;
+	width: 100%;
+}
+
 .sheet-body {
 	padding: 1rem;
 	display: flex;
 	flex-direction: column;
 	gap: 0.4rem;
+	font-family: 'Oswald', sans-serif;
+	text-align: center;
+}
+
+.modal-img {
+	display: block;
+	max-width: 80%;
+	margin: 0 auto 1rem;
 }
 
 .sheet-footer {

--- a/src/RecordModal/RecordModal.css
+++ b/src/RecordModal/RecordModal.css
@@ -1,3 +1,19 @@
+.sheet-body {
+	padding: 1rem;
+	display: flex;
+	flex-direction: column;
+	gap: 0.4rem;
+}
+
+.sheet-footer {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	padding: 0.75rem 1rem;
+	border-top: 1px solid #dddddd;
+	flex-shrink: 0;
+}
+
 .note {
 	font-family: Oswald;
 	text-align: center;

--- a/src/RecordModal/RecordModal.jsx
+++ b/src/RecordModal/RecordModal.jsx
@@ -330,41 +330,43 @@ function RecordModal(props) {
 						{error}
 					</p>
 				)}
-				<div>
-					<label htmlFor='title'>Title:</label>
-					<input required ref={titleRef} className='inputField' type='text' id='title' value={inputs.title} onChange={handleInputChange} />
-				</div>
-				<div>
-					<label htmlFor='artist_id'>Artist:</label>
-					<ArtistCombobox
-						artists={artists}
-						value={inputs.artist_id}
-						onChange={(id) => handleInputChange({ target: { id: 'artist_id', value: id } })}
-					/>
-				</div>
-				<div>
-					<label htmlFor='genre'>Genre:</label>
-					<input className='inputField' type='text' id='genre' value={inputs.genre} onChange={handleInputChange} />
-				</div>
-				<div>
-					<label htmlFor='label'>Label:</label>
-					<input className='inputField' type='text' id='label' value={inputs.label} onChange={handleInputChange} />
-				</div>
-				<div>
-					<label htmlFor='release_date'>Release date:</label>
-					<input className='inputField' type='date' id='release_date' value={inputs.release_date || ''} onChange={handleInputChange} />
-				</div>
-				<div>
-					<label htmlFor='acquired_date'>Acquired date:</label>
-					<input className='inputField' type='date' id='acquired_date' value={inputs.acquired_date || ''} onChange={handleInputChange} />
-				</div>
-				<div>
-					<label htmlFor='photo_url'>Photo URL:</label>
-					<input className='inputField' type='text' id='photo_url' value={inputs.photo_url} onChange={handleInputChange} />
-				</div>
-				<div>
-					<label htmlFor='notes'>Notes:</label>
-					<input className='inputField' type='text' id='notes' value={inputs.notes} onChange={handleInputChange} />
+				<div className='editInputs'>
+					<div>
+						<label htmlFor='title'>Title:</label>
+						<input required ref={titleRef} className='inputField' type='text' id='title' value={inputs.title} onChange={handleInputChange} />
+					</div>
+					<div>
+						<label htmlFor='artist_id'>Artist:</label>
+						<ArtistCombobox
+							artists={artists}
+							value={inputs.artist_id}
+							onChange={(id) => handleInputChange({ target: { id: 'artist_id', value: id } })}
+						/>
+					</div>
+					<div>
+						<label htmlFor='genre'>Genre:</label>
+						<input className='inputField' type='text' id='genre' value={inputs.genre} onChange={handleInputChange} />
+					</div>
+					<div>
+						<label htmlFor='label'>Label:</label>
+						<input className='inputField' type='text' id='label' value={inputs.label} onChange={handleInputChange} />
+					</div>
+					<div>
+						<label htmlFor='release_date'>Release date:</label>
+						<input className='inputField' type='date' id='release_date' value={inputs.release_date || ''} onChange={handleInputChange} />
+					</div>
+					<div>
+						<label htmlFor='acquired_date'>Acquired date:</label>
+						<input className='inputField' type='date' id='acquired_date' value={inputs.acquired_date || ''} onChange={handleInputChange} />
+					</div>
+					<div>
+						<label htmlFor='photo_url'>Photo URL:</label>
+						<input className='inputField' type='text' id='photo_url' value={inputs.photo_url} onChange={handleInputChange} />
+					</div>
+					<div>
+						<label htmlFor='notes'>Notes:</label>
+						<textarea className='inputField notes-input' id='notes' value={inputs.notes} onChange={handleInputChange} />
+					</div>
 				</div>
 				<div className='tracklist-edit'>
 					<h6 className='tracklist-title'>Tracklist</h6>

--- a/src/RecordModal/RecordModal.jsx
+++ b/src/RecordModal/RecordModal.jsx
@@ -1,6 +1,4 @@
 import React, { useState, useEffect, useRef } from 'react';
-import Modal from 'react-bootstrap/Modal';
-import ModalHeader from 'react-bootstrap/esm/ModalHeader';
 import {
 	DndContext,
 	closestCenter,
@@ -17,6 +15,7 @@ import {
 import { CSS } from '@dnd-kit/utilities';
 import useEditRecord from '../EditRecordHook';
 import ArtistCombobox from '../ArtistCombobox/ArtistCombobox';
+import BottomSheet from '../BottomSheet/BottomSheet';
 import axios from '../axios';
 import requests from '../requests';
 import './RecordModal.css';
@@ -69,19 +68,13 @@ function SortableTrackItem({ song, onEdit, onDelete, editingId }) {
 							className='inputField track-num-input'
 							type='text'
 							value={editTrack}
-							onChange={(e) => {
-								const val = e.target.value;
-								setEditTrack(val);
-							}}
+							onChange={(e) => setEditTrack(e.target.value)}
 						/>
 						<input
 							className='inputField track-title-input'
 							type='text'
 							value={editTitle}
-							onChange={(e) => {
-								const val = e.target.value;
-								setEditTitle(val);
-							}}
+							onChange={(e) => setEditTitle(e.target.value)}
 						/>
 					</div>
 					<div className='track-edit-actions'>
@@ -144,7 +137,6 @@ function RecordModal(props) {
 
 	const sensors = useSensors(useSensor(PointerSensor));
 
-	// Reset modal state when a different record is opened
 	useEffect(() => {
 		setIsEditing(false);
 		setIsConfirmingDelete(false);
@@ -154,30 +146,22 @@ function RecordModal(props) {
 		setSongs(currentRecord.songs || []);
 	}, [currentRecord.id]);
 
-	// Keep songs in sync when currentRecord updates
 	useEffect(() => {
 		setSongs(currentRecord.songs || []);
 	}, [currentRecord.songs]);
 
-	// Fetch artists when entering edit mode
 	useEffect(() => {
 		if (isEditing) {
 			axios.get(requests.postArtistURL).then((res) => setArtists(res.data));
 		}
 	}, [isEditing]);
 
-	// Focus title input when edit mode opens
 	useEffect(() => {
-		if (isEditing && titleRef.current) {
-			titleRef.current.focus();
-		}
+		if (isEditing && titleRef.current) titleRef.current.focus();
 	}, [isEditing]);
 
-	// Focus track title input when add track form opens
 	useEffect(() => {
-		if (showAddTrack && newTrackTitleRef.current) {
-			newTrackTitleRef.current.focus();
-		}
+		if (showAddTrack && newTrackTitleRef.current) newTrackTitleRef.current.focus();
 	}, [showAddTrack]);
 
 	const onSuccess = (updatedRecord) => {
@@ -210,30 +194,15 @@ function RecordModal(props) {
 	const handleDeleteSong = (songId) => {
 		setSongError('');
 		axios.delete(requests.songDetailURL(songId))
-			.then(() => {
-				setSongs((prev) => prev.filter((s) => s.id !== songId));
-			})
+			.then(() => setSongs((prev) => prev.filter((s) => s.id !== songId)))
 			.catch(() => setSongError('Could not delete track. Please try again.'));
 	};
 
 	const handleEditSong = (songId, track, title) => {
-		if (songId === null) {
-			// Cancel
-			setEditingId(null);
-			return;
-		}
-		if (track === null && title === null) {
-			// Enter edit mode
-			setSongError('');
-			setEditingId(songId);
-			return;
-		}
-		// Save
+		if (songId === null) { setEditingId(null); return; }
+		if (track === null && title === null) { setSongError(''); setEditingId(songId); return; }
 		axios
-			.patch(requests.songDetailURL(songId), {
-				track: track || null,
-				title,
-			})
+			.patch(requests.songDetailURL(songId), { track: track || null, title })
 			.then((res) => {
 				setSongs((prev) =>
 					prev.map((s) => (s.id === songId ? { ...s, track: res.data.track, title: res.data.title } : s))
@@ -246,12 +215,10 @@ function RecordModal(props) {
 	const handleDragEnd = (event) => {
 		const { active, over } = event;
 		if (!over || active.id === over.id) return;
-
 		setSongs((prev) => {
 			const oldIndex = prev.findIndex((s) => s.id === active.id);
 			const newIndex = prev.findIndex((s) => s.id === over.id);
-			const reordered = arrayMove(prev, oldIndex, newIndex);
-			return reordered.map((song, i) => ({ ...song, track: i + 1 }));
+			return arrayMove(prev, oldIndex, newIndex).map((song, i) => ({ ...song, track: i + 1 }));
 		});
 	};
 
@@ -267,13 +234,11 @@ function RecordModal(props) {
 		Promise.all(patches).then(() => performUpdate());
 	};
 
-	const { inputs, handleInputChange, handleUpdate, performUpdate, handleDelete, error } =
+	const { inputs, handleInputChange, performUpdate, handleDelete, error } =
 		useEditRecord(currentRecord, onSuccess);
 
 	const currentSongs = currentRecord.songs || [];
-	const songOrderChanged = songs.some(
-		(s, i) => !currentSongs[i] || s.id !== currentSongs[i].id
-	);
+	const songOrderChanged = songs.some((s, i) => !currentSongs[i] || s.id !== currentSongs[i].id);
 
 	const isDirty =
 		inputs.title !== (currentRecord.title || '') ||
@@ -286,7 +251,7 @@ function RecordModal(props) {
 		inputs.notes !== (currentRecord.notes || '') ||
 		songOrderChanged;
 
-	const handleModalClose = () => {
+	const handleSheetClose = () => {
 		if (isEditing && isDirty) return;
 		if (isEditing) {
 			setIsEditing(false);
@@ -299,33 +264,17 @@ function RecordModal(props) {
 
 	const readView = (
 		<>
-			<Modal.Body>
+			<div className='sheet-body'>
 				{currentRecord.photo_url && (
-					<img
-						className='modal-img'
-						alt={currentRecord.title}
-						src={currentRecord.photo_url}
-					/>
+					<img className='modal-img' alt={currentRecord.title} src={currentRecord.photo_url} />
 				)}
 				<div className='modal-details'>
-					{currentRecord.artist_string && (
-						<p>Artist: {currentRecord.artist_string}</p>
-					)}
-					{currentRecord.genre && (
-						<p>Genre: {currentRecord.genre}</p>
-					)}
-					{currentRecord.label && (
-						<p>Label: {currentRecord.label}</p>
-					)}
-					{currentRecord.release_date && (
-						<p>Release date: {formatDate(currentRecord.release_date)}</p>
-					)}
-					{currentRecord.acquired_date && (
-						<p>Acquired date: {formatDate(currentRecord.acquired_date)}</p>
-					)}
-					{currentRecord.notes && (
-						<p className='note'>{currentRecord.notes}</p>
-					)}
+					{currentRecord.artist_string && <p>Artist: {currentRecord.artist_string}</p>}
+					{currentRecord.genre && <p>Genre: {currentRecord.genre}</p>}
+					{currentRecord.label && <p>Label: {currentRecord.label}</p>}
+					{currentRecord.release_date && <p>Release date: {formatDate(currentRecord.release_date)}</p>}
+					{currentRecord.acquired_date && <p>Acquired date: {formatDate(currentRecord.acquired_date)}</p>}
+					{currentRecord.notes && <p className='note'>{currentRecord.notes}</p>}
 				</div>
 				{songs.length > 0 && (
 					<div className='tracklist'>
@@ -340,8 +289,8 @@ function RecordModal(props) {
 						</ol>
 					</div>
 				)}
-			</Modal.Body>
-			<Modal.Footer style={{ justifyContent: 'space-between' }}>
+			</div>
+			<div className='sheet-footer'>
 				{isConfirmingDelete ? (
 					<>
 						<span>Delete <strong>{currentRecord.title}</strong>? This cannot be undone.</span>
@@ -369,13 +318,13 @@ function RecordModal(props) {
 						</button>
 					</>
 				)}
-			</Modal.Footer>
+			</div>
 		</>
 	);
 
 	const editView = (
 		<form onSubmit={handleSaveWithReorder} autoComplete='off'>
-			<Modal.Body>
+			<div className='sheet-body'>
 				{error && (
 					<p role='alert' style={{ color: '#b94a48', fontWeight: 'bold' }}>
 						{error}
@@ -383,15 +332,7 @@ function RecordModal(props) {
 				)}
 				<div>
 					<label htmlFor='title'>Title:</label>
-					<input
-						required
-						ref={titleRef}
-						className='inputField'
-						type='text'
-						id='title'
-						value={inputs.title}
-						onChange={handleInputChange}
-					/>
+					<input required ref={titleRef} className='inputField' type='text' id='title' value={inputs.title} onChange={handleInputChange} />
 				</div>
 				<div>
 					<label htmlFor='artist_id'>Artist:</label>
@@ -403,65 +344,28 @@ function RecordModal(props) {
 				</div>
 				<div>
 					<label htmlFor='genre'>Genre:</label>
-					<input
-						className='inputField'
-						type='text'
-						id='genre'
-						value={inputs.genre}
-						onChange={handleInputChange}
-					/>
+					<input className='inputField' type='text' id='genre' value={inputs.genre} onChange={handleInputChange} />
 				</div>
 				<div>
 					<label htmlFor='label'>Label:</label>
-					<input
-						className='inputField'
-						type='text'
-						id='label'
-						value={inputs.label}
-						onChange={handleInputChange}
-					/>
+					<input className='inputField' type='text' id='label' value={inputs.label} onChange={handleInputChange} />
 				</div>
 				<div>
 					<label htmlFor='release_date'>Release date:</label>
-					<input
-						className='inputField'
-						type='date'
-						id='release_date'
-						value={inputs.release_date || ''}
-						onChange={handleInputChange}
-					/>
+					<input className='inputField' type='date' id='release_date' value={inputs.release_date || ''} onChange={handleInputChange} />
 				</div>
 				<div>
 					<label htmlFor='acquired_date'>Acquired date:</label>
-					<input
-						className='inputField'
-						type='date'
-						id='acquired_date'
-						value={inputs.acquired_date || ''}
-						onChange={handleInputChange}
-					/>
+					<input className='inputField' type='date' id='acquired_date' value={inputs.acquired_date || ''} onChange={handleInputChange} />
 				</div>
 				<div>
 					<label htmlFor='photo_url'>Photo URL:</label>
-					<input
-						className='inputField'
-						type='text'
-						id='photo_url'
-						value={inputs.photo_url}
-						onChange={handleInputChange}
-					/>
+					<input className='inputField' type='text' id='photo_url' value={inputs.photo_url} onChange={handleInputChange} />
 				</div>
 				<div>
 					<label htmlFor='notes'>Notes:</label>
-					<input
-						className='inputField'
-						type='text'
-						id='notes'
-						value={inputs.notes}
-						onChange={handleInputChange}
-					/>
+					<input className='inputField' type='text' id='notes' value={inputs.notes} onChange={handleInputChange} />
 				</div>
-
 				<div className='tracklist-edit'>
 					<h6 className='tracklist-title'>Tracklist</h6>
 					{songError && (
@@ -470,13 +374,8 @@ function RecordModal(props) {
 						</p>
 					)}
 					{songs.length > 0 && (
-						<DndContext
-							sensors={sensors}
-							collisionDetection={closestCenter}
-							onDragEnd={handleDragEnd}>
-							<SortableContext
-								items={songs.map((s) => s.id)}
-								strategy={verticalListSortingStrategy}>
+						<DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+							<SortableContext items={songs.map((s) => s.id)} strategy={verticalListSortingStrategy}>
 								<ul className='tracklist-edit-items'>
 									{songs.map((song) => (
 										<SortableTrackItem
@@ -498,10 +397,7 @@ function RecordModal(props) {
 								type='text'
 								placeholder='#'
 								value={newTrack.track}
-								onChange={(e) => {
-									const val = e.target.value;
-									setNewTrack((t) => ({ ...t, track: val }));
-								}}
+								onChange={(e) => setNewTrack((t) => ({ ...t, track: e.target.value }))}
 							/>
 							<input
 								ref={newTrackTitleRef}
@@ -509,26 +405,17 @@ function RecordModal(props) {
 								type='text'
 								placeholder='Track title'
 								value={newTrack.title}
-								onChange={(e) => {
-									const val = e.target.value;
-									setNewTrack((t) => ({ ...t, title: val }));
-								}}
+								onChange={(e) => setNewTrack((t) => ({ ...t, title: e.target.value }))}
 							/>
 							<div className='add-track-actions'>
 								<button
 									type='button'
 									className='modal-btn'
 									style={{ marginRight: '8px' }}
-									onClick={() => {
-										setShowAddTrack(false);
-										setNewTrack({ track: '', title: '' });
-									}}>
+									onClick={() => { setShowAddTrack(false); setNewTrack({ track: '', title: '' }); }}>
 									Cancel
 								</button>
-								<button
-									type='button'
-									className='modal-btn'
-									onClick={handleAddSong}>
+								<button type='button' className='modal-btn' onClick={handleAddSong}>
 									Add
 								</button>
 							</div>
@@ -545,8 +432,8 @@ function RecordModal(props) {
 						</button>
 					)}
 				</div>
-			</Modal.Body>
-			<Modal.Footer style={{ justifyContent: 'space-between' }}>
+			</div>
+			<div className='sheet-footer'>
 				<button
 					className='modal-btn'
 					type='button'
@@ -560,17 +447,14 @@ function RecordModal(props) {
 				<button className='modal-btn' type='submit'>
 					Save
 				</button>
-			</Modal.Footer>
+			</div>
 		</form>
 	);
 
 	return (
-		<Modal centered show={props.show} onHide={handleModalClose}>
-			<ModalHeader closeButton>
-				<Modal.Title>{currentRecord.title}</Modal.Title>
-			</ModalHeader>
+		<BottomSheet show={props.show} onClose={handleSheetClose} title={currentRecord.title}>
 			{isEditing ? editView : readView}
-		</Modal>
+		</BottomSheet>
 	);
 }
 

--- a/src/RecordsList/RecordsList.css
+++ b/src/RecordsList/RecordsList.css
@@ -32,37 +32,6 @@ h2 {
 	font-size: x-large;
 }
 
-.modal-body {
-	/* position: fixed;
-	z-index: 1; */
-	/* display: grid; */
-	/* background-color: coral; */
-	text-align: center;
-	font-family: 'Oswald';
-}
-
-/* .modal-div {
-	position: fixed;
-	top: 0;
-	left: 0;
-	height: 100%;
-	width: 100%;
-	z-index: 1;
-} */
-
-.modal-title {
-	text-align: center;
-	padding: 2rem;
-	font-family: 'Oswald';
-}
-
-.modal-img {
-	max-width: 80%;
-}
-
-.modal-link:hover {
-	color: #444444;
-}
 
 @media (min-width: 650px) {
 	.record-list-grid {

--- a/src/index.css
+++ b/src/index.css
@@ -30,6 +30,11 @@ code {
 	border-color: #333333;
 }
 
+.notes-input {
+	resize: vertical;
+	min-height: 4rem;
+}
+
 .editInputs {
 	display: flex;
 	flex-direction: column;


### PR DESCRIPTION
## Summary

- Replace React Bootstrap modal with custom BottomSheet component (slides up on mobile, centered modal on desktop)
- Remove Bootstrap dependency entirely; bundle reduced ~22KB
- Add Artists management hub at /artists with create, edit, delete, and search
- Polish UI across RecordModal, Artists, and NewRecord pages

## Changes

- BottomSheet: portal-based, body scroll lock, animated open/close, Escape key support
- RecordModal: restore Oswald font and centering after Bootstrap removal; fix image centering; expand edit fields to full width
- Artists: header row with title and Add button; full-width search and add form; notes as textarea
- NewRecord: Cancel button, consistent page layout, notes as textarea
- Remove stale Bootstrap-targeted styles from RecordsList.css

## Test plan

- [ ] Open a record — sheet slides up on mobile, centered on desktop
- [ ] Edit a record — form fields full width, fonts consistent, image centered
- [ ] Escape with dirty form does nothing; Escape with clean form exits edit mode
- [ ] Add, edit, and delete an artist at /artists
- [ ] Delete blocked for artists with albums; tooltip on desktop, inline message on mobile
- [ ] Add new record with Cancel navigating back to home